### PR TITLE
Fixed issue with P/NP would not display without Advanced Options 

### DIFF
--- a/src/Components/Search/calculations.js
+++ b/src/Components/Search/calculations.js
@@ -111,7 +111,7 @@ export function cumulativeData(original_data, data, params, option = true){
         stats.f = agg.sum_grade_f_count;
         stats.p = agg.sum_grade_p_count;
         stats.np = agg.sum_grade_np_count;
-        stats.gpa = agg.average_gpa.toFixed(2);
+        stats.gpa = (agg.average_gpa === null) ? 0.00.toFixed(2) : agg.average_gpa.toFixed(2);
         // let avg_manual = ((stats.a * 4) + (stats.b * 3) + (stats.c * 2) + (stats.d))/(stats.a + stats.b + stats.c + stats.d + stats.f)
         // console.log('manual:', avg_manual)
         // console.log('from api:', agg.average_gpa)


### PR DESCRIPTION
# Summary
Zotistics fails to display P/NP only classes if either Lower Div/Upper Div checkboxes are selected. The reason for this issue is that it currently fails to account that the average GPA is null. 

On [Line 114](https://github.com/icssc-projects/Zotistics/blob/16517fded78cf840581d425d1200275af66a29f6/src/Components/Search/calculations.js#L114), `agg.average_gpa` is null if there are only P/NP classes, which results in the calculation failing. 

The reason it works when Lower Div/Upper Div is selected is the GPA calculation goes to the else statement on [Line 119](https://github.com/icssc-projects/Zotistics/blob/16517fded78cf840581d425d1200275af66a29f6/src/Components/Search/calculations.js#L119) when advanced options are selected. 

# Test Plan
- Select a P/NP only class without selecting any Advanced Options checkboxes 
- Verify that the results are shown.

Example P/NP Class:
- Instructor: Pattis, R.
- Class Number: 90 
![image](https://user-images.githubusercontent.com/41417417/145538306-e82cb9e9-61c5-4e28-9a29-d03483c243e8.png)
