### PR TITLE
Fixed bug where P/NP info is still displayed even if 'Exclude P/NP' is selected

### DIFF
--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -60,7 +60,7 @@ export default function Search({ nightMode }) {
         classNumber: query.get("classNumber") || "",
         classCode: query.get("classCode") || "",
         advancedVisible: query.get("advancedVisible") || false,
-        excludePNP: query.get("exludePNP") || false,
+        excludePNP: query.get("excludePNP") || false,
         covid19: query.get("covid19") || false,
         lowerDiv: query.get("lowerDiv") || false,
         upperDiv: query.get("upperDiv") || false

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -25,7 +25,64 @@ const GRAPHQL_INSTRUCTOR_QUERY = `
       }
     }
 `
-
+const GRAPHQL_GRADE_QUERY = `
+    query(
+        $instructor: String
+        $quarter: String
+        $year: String
+        $department: String
+        $number: String
+        $code: String
+        $excludePNP: Boolean!
+    ) {
+        grades(
+        instructor: $instructor
+        quarter: $quarter
+        year: $year
+        department: $department
+        number: $number
+        code: $code
+        excludePNP: $excludePNP
+        ) {
+        aggregate {
+            sum_grade_a_count
+            sum_grade_b_count
+            sum_grade_c_count
+            sum_grade_d_count
+            sum_grade_f_count
+            sum_grade_p_count @skip(if: $excludePNP)
+            sum_grade_np_count @skip(if: $excludePNP)
+            average_gpa
+        }
+        grade_distributions {
+            grade_a_count
+            grade_b_count
+            grade_c_count
+            grade_d_count
+            grade_f_count
+            grade_p_count @skip(if: $excludePNP)
+            grade_np_count @skip(if: $excludePNP)
+            average_gpa
+            course_offering {
+            year
+            quarter
+            instructors {
+                name
+                shortened_name
+            }
+            section {
+                code
+            }
+            course {
+                department
+                number
+                title
+            }
+            }
+        }
+        }
+    }
+`
 
 const INITIAL_INSTRUCTORS = [
     { name: "SHEPHERD, B.", value: "SHEPHERD, B." },
@@ -185,7 +242,7 @@ export default function Search({ nightMode }) {
     */
     const fetchDataFromForm = async (formID) => {
         return fetch(API_URL, {
-            body: JSON.stringify({"query": calc.searchQuery(forms[formID])}),
+            body: JSON.stringify({"query": GRAPHQL_GRADE_QUERY, "variables": calc.getQueryVariables(forms[formID])}),
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -194,7 +251,7 @@ export default function Search({ nightMode }) {
             .then(res => res.json())
             .then(data => {
                 let params = forms[formID];
-                let filtered = calc.filter(data.data.grades.grade_distributions, params.excludePNP, params.covid19, params.lowerDiv, params.upperDiv);
+                let filtered = calc.filter(data.data.grades.grade_distributions, params.covid19, params.lowerDiv, params.upperDiv);
                 let classList = filtered.reverse() // reversed to order it from most recent to oldest
                 let result = calc.calculateData(classList, params, data)
                 setQueryParams(params);

--- a/src/Components/Search/calculations.js
+++ b/src/Components/Search/calculations.js
@@ -213,8 +213,7 @@ export function searchQuery(params){
               sum_grade_c_count
               sum_grade_d_count
               sum_grade_f_count
-              sum_grade_p_count
-              sum_grade_np_count
+              ${(params.excludePNP) ? "" : "sum_grade_p_count sum_grade_np_count"}
               average_gpa
             }
             grade_distributions{
@@ -223,8 +222,7 @@ export function searchQuery(params){
               grade_c_count
               grade_d_count
               grade_f_count
-              grade_p_count
-              grade_np_count
+              ${(params.excludePNP) ? "" : "grade_p_count grade_np_count"}
               average_gpa
               course_offering{
                 year

--- a/src/Components/Search/calculations.js
+++ b/src/Components/Search/calculations.js
@@ -136,7 +136,7 @@ export function cumulativeData(original_data, data, params, option = true){
 /*
   Filters the api result based on the advanced options in the query
  */
-export function filter(data, excludePNP, covid19, lowerDiv, upperDiv){
+export function filter(data, covid19, lowerDiv, upperDiv){
     let final = [];
 
     for(let c of data){
@@ -162,11 +162,6 @@ export function filter(data, excludePNP, covid19, lowerDiv, upperDiv){
                 (co.year === '2020-21' && co.quarter.toUpperCase() === 'FALL') ||
                 (co.year === '2020-21' && co.quarter.toUpperCase() === 'WINTER')){
                 push = false;
-            }
-        }
-        if(excludePNP){
-            if(c.grade_a_count === 0 && c.grade_b_count === 0 && c.grade_c_count === 0 && c.grade_d_count === 0 && c.grade_f_count === 0){
-                push = false
             }
         }
 
@@ -197,51 +192,20 @@ export function calculateData(data, params, originalData, option) {
     };
 }
 
-export function searchQuery(params){
+/*
+    Constructs variables for GraphQL grade distribution query
+*/
+export function getQueryVariables(params) {
     let quarters = params.quarters.join(';');
     let years = params.years.join(';');
-    let code = (params.classCode !== '') ? parseFloat(params.classCode) : null;
-    let args = `instructor: "${params.instructor}", quarter: "${quarters}", year: "${years}", department: "${params.department}",
-        number: "${params.classNumber}", code: ${code}`;
 
-    return `
-        query {
-          grades(${args}) {
-            aggregate{
-              sum_grade_a_count
-              sum_grade_b_count
-              sum_grade_c_count
-              sum_grade_d_count
-              sum_grade_f_count
-              ${(params.excludePNP) ? "" : "sum_grade_p_count sum_grade_np_count"}
-              average_gpa
-            }
-            grade_distributions{
-              grade_a_count
-              grade_b_count
-              grade_c_count
-              grade_d_count
-              grade_f_count
-              ${(params.excludePNP) ? "" : "grade_p_count grade_np_count"}
-              average_gpa
-              course_offering{
-                year
-                quarter
-                instructors{
-                  name
-                  shortened_name
-                }
-                section{
-                  code
-                }
-                course {
-                  department
-                  number
-                  title
-                }
-              }
-            }
-          }
-        }
-        `
+    return {
+        "instructor": params.instructor,
+        "quarter": quarters,
+        "year": years,
+        "department": params.department,
+        "number": params.number,
+        "code": params.code,
+        "excludePNP": params.excludePNP
+    }
 }


### PR DESCRIPTION
# Summary
There is a bug where P/NP information is displayed for classes with both a grade and P/NP option (i.e. I&CS 31). Changed the query to exclude `grade_p_count` and `grade_np_count` when the `Exclude P/NP` option is selected.

# Test Plan
- Select a class with both grade and P/NP options (i.e. I&CS 31). 
- Check the `Exclude P/NP` option.
- Verify that P/NP information is excluded from the results.

![image](https://user-images.githubusercontent.com/41417417/145671985-c18669ab-fe88-452b-a6b2-96883a3aa95b.png)

# Issues
Resolves issue #15 