### PR TITLE
Fixed bug where dark mode could not be toggled when graph is shown

### DIFF
--- a/src/Components/Dog/dog.css
+++ b/src/Components/Dog/dog.css
@@ -2,12 +2,12 @@
     position: fixed;
     left:1em;
     bottom:0;
-    z-index:-1;
+    z-index:1;
 }
 
 img{
     max-width:33%;
-    height: auto;   
+    height: auto;
     transition: transform 0.2s ease-in-out;
 }
 


### PR DESCRIPTION
# Summary
There is a bug where dark mode could not be toggled when a graph is shown.

The reason for this issue is the `search-content-wrapper` div, which is displayed when a graph is shown, overlaps with the `dog` div, which makes the `dog` div unselectable.

# Test Plan
- Verify that dark mode can be toggled without a graph displayed
- Display any grade distribution
- Verify that dark mode can be toggled with a graph displayed

# Issues
Resolves issue #10 