### PR TITLE
Added 2020-2021 Spring quarter to be to excluded for the COVID-19 option

### DIFF
--- a/src/Components/Search/calculations.js
+++ b/src/Components/Search/calculations.js
@@ -189,8 +189,7 @@ export function calculateData(data, params, originalData, option) {
 
     return {
         count: count, a: stats.a, b: stats.b, c: stats.c, d: stats.d, f: stats.f, p: stats.p, np: stats.np,
-        averageGPA: stats.gpa, classes: classes, instructors: instructors,
-        instructor: params.instructor, quarter: displayTerm.quarter, year: displayTerm.year,
+        averageGPA: stats.gpa, instructor: params.instructor, quarter: displayTerm.quarter, year: displayTerm.year,
         department: params.department, classNumber: params.classNumber,
         classCode: params.classCode, courseList: data
     };

--- a/src/Components/Search/calculations.js
+++ b/src/Components/Search/calculations.js
@@ -136,7 +136,7 @@ export function cumulativeData(original_data, data, params, option = true) {
 /*
   Filters the api result based on the advanced options in the query
  */
-export function filter(data, excludePNP, covid19, lowerDiv, upperDiv) {
+export function filter(data, covid19, lowerDiv, upperDiv) {
     let final = [];
 
     for (let c of data) {

--- a/src/Components/Search/calculations.js
+++ b/src/Components/Search/calculations.js
@@ -3,19 +3,19 @@
   Returns object of classes and their occurrences to use
   in the side bar of the results page next to the graph
  */
-export function classList(data){
+export function classList(data) {
     let classes = {}; // { className: {count, {year, quarter, code, instructor}} }
 
-    for(let classObject of data){
+    for (let classObject of data) {
         let c = classObject.course_offering;
         let className = `${c.course.department} ${c.course.number}`;
-        let course = {year: c.year, quarter: c.quarter, code: c.section.code, instructor: c.instructors[0].shortened_name};
+        let course = { year: c.year, quarter: c.quarter, code: c.section.code, instructor: c.instructors[0].shortened_name };
 
-        if(className in classes){
+        if (className in classes) {
             classes[className].count++;
             classes[className].courses.push(course);
         } else {
-            classes[className] = {count: 1, courses: [course]};
+            classes[className] = { count: 1, courses: [course] };
             classes[className].department = c.course.department
             classes[className].number = c.course.number
         }
@@ -31,12 +31,12 @@ export function classList(data){
   Returns object of instructors and their occurrences to use
   in the side bar of the results page next to the graph
  */
-export function instructorList(data){
+export function instructorList(data) {
     let instructors = {};
 
-    for(let classObject of data){
+    for (let classObject of data) {
         let teacher = classObject.course_offering.instructors[0].shortened_name
-        if(teacher in instructors){
+        if (teacher in instructors) {
             instructors[teacher]++;
         } else {
             instructors[teacher] = 1;
@@ -52,13 +52,13 @@ export function instructorList(data){
   Returns exact year from a quarter and year combo
   Winter 2017-18 => Winter 2018
  */
-export function exactYear(quarter, year){
+export function exactYear(quarter, year) {
     let yearSplit = year.split('-');
     let quarterUpper = quarter.toUpperCase()
     let exactYear;
-    if(quarterUpper === 'SUMMER' || quarterUpper === 'FALL'){
+    if (quarterUpper === 'SUMMER' || quarterUpper === 'FALL') {
         exactYear = yearSplit[0]
-    } else if(quarterUpper === 'WINTER' || quarterUpper === 'SPRING'){
+    } else if (quarterUpper === 'WINTER' || quarterUpper === 'SPRING') {
         exactYear = yearSplit[0][0] + yearSplit[0][1] + yearSplit[1]
     }
 
@@ -69,25 +69,25 @@ export function exactYear(quarter, year){
   Returns exact quarter and year from the search query
   Winter 2017-18 => Winter 2018
  */
-export function quarterYear(quarters, years){
-    if(quarters.length === 1 && years.length === 1){
-        return {quarter: quarters[0], year: exactYear(quarters[0], years[0])}
-    } else if(quarters.length === 1 && years.length === 0){
-        return {quarter: quarters[0], year: ''}
-    } else if(quarters.length === 0 && years.length === 1){
-        return {quarter: '', year: years[0]}
-    } else if(quarters.length === 0 && years.length === 0){
-        return {quarter: 'All', year: ''}
+export function quarterYear(quarters, years) {
+    if (quarters.length === 1 && years.length === 1) {
+        return { quarter: quarters[0], year: exactYear(quarters[0], years[0]) }
+    } else if (quarters.length === 1 && years.length === 0) {
+        return { quarter: quarters[0], year: '' }
+    } else if (quarters.length === 0 && years.length === 1) {
+        return { quarter: '', year: years[0] }
+    } else if (quarters.length === 0 && years.length === 0) {
+        return { quarter: 'All', year: '' }
     } else {
-        return {quarter: 'Custom', year: ''}
+        return { quarter: 'Custom', year: '' }
     }
 }
 
 /*
   Adds additional data for each course in the api result
  */
-export function addData(data){
-    for(let i = 0; i < data.length; i++){
+export function addData(data) {
+    for (let i = 0; i < data.length; i++) {
         let quarter = data[i].course_offering.quarter.toUpperCase();
         let year = data[i].course_offering.year;
         data[i].course_offering.exact_year = exactYear(quarter, year);
@@ -99,10 +99,10 @@ export function addData(data){
 /*
   Sums up the amount of grades in the query and averages the gpa
  */
-export function cumulativeData(original_data, data, params, option = true){
-    let stats = {a: 0, b: 0, c: 0, d: 0, f: 0, p: 0, np: 0, gpa: 0}
+export function cumulativeData(original_data, data, params, option = true) {
+    let stats = { a: 0, b: 0, c: 0, d: 0, f: 0, p: 0, np: 0, gpa: 0 }
 
-    if(option && !params.excludePNP && !params.covid19 && !params.lowerDiv && !params.upperDiv){ // no advanced options
+    if (option && !params.excludePNP && !params.covid19 && !params.lowerDiv && !params.upperDiv) { // no advanced options
         let agg = original_data.data.grades.aggregate
         stats.a = agg.sum_grade_a_count;
         stats.b = agg.sum_grade_b_count;
@@ -117,7 +117,7 @@ export function cumulativeData(original_data, data, params, option = true){
         // console.log('from api:', agg.average_gpa)
 
     } else { // if at least one advanced option is true
-        for(let classObject of data){
+        for (let classObject of data) {
             stats.a += classObject.grade_a_count;
             stats.b += classObject.grade_b_count;
             stats.c += classObject.grade_c_count;
@@ -136,36 +136,41 @@ export function cumulativeData(original_data, data, params, option = true){
 /*
   Filters the api result based on the advanced options in the query
  */
-export function filter(data, covid19, lowerDiv, upperDiv){
+export function filter(data, excludePNP, covid19, lowerDiv, upperDiv) {
     let final = [];
 
-    for(let c of data){
+    for (let c of data) {
         let push = true;
         let co = c.course_offering;
 
-        if(lowerDiv === true && upperDiv === false){
+        if (lowerDiv && !upperDiv) {
             let num = parseInt(co.course.number.replace(/\D/g, ""));
-            if(num >= 100){
+            if (num >= 100) {
                 push = false;
             }
         }
-        if(upperDiv === true && lowerDiv === false){
+        if (upperDiv && !lowerDiv) {
             let num = parseInt(co.course.number.replace(/\D/g, ""));
-            if(num < 100){
+            if (num < 100) {
                 push = false;
             }
         }
-        if(covid19 === true){
-            if((co.year === '2019-20' && co.quarter.toUpperCase() === 'WINTER') ||
-                (co.year === '2019-20' && co.quarter.toUpperCase() === 'SPRING') ||
-                (co.year === '2020-21' && co.quarter.toUpperCase() === 'SUMMER') ||
-                (co.year === '2020-21' && co.quarter.toUpperCase() === 'FALL') ||
-                (co.year === '2020-21' && co.quarter.toUpperCase() === 'WINTER')){
+        if (covid19) {
+            const covid_quarters = new Set([
+                '2019-20 WINTER',
+                '2019-20 SPRING',
+                '2020-21 SUMMER',
+                '2020-21 FALL',
+                '2020-21 WINTER',
+                '2020-21 SPRING'
+            ]);
+
+            if (covid_quarters.has(co.year + " " + co.quarter.toUpperCase())) {
                 push = false;
             }
         }
 
-        if(push === true){
+        if (push) {
             final.push(c);
         }
     }
@@ -182,8 +187,10 @@ export function calculateData(data, params, originalData, option) {
     let stats = cumulativeData(originalData, data, params, option); // object that has grade data
     let displayTerm = quarterYear(params.quarters, params.years); // used to display term in results page above graph
 
-    return {count: count, a: stats.a, b: stats.b, c: stats.c, d: stats.d, f: stats.f, p: stats.p, np: stats.np,
-        averageGPA: stats.gpa, instructor: params.instructor, quarter: displayTerm.quarter, year: displayTerm.year,
+    return {
+        count: count, a: stats.a, b: stats.b, c: stats.c, d: stats.d, f: stats.f, p: stats.p, np: stats.np,
+        averageGPA: stats.gpa, classes: classes, instructors: instructors,
+        instructor: params.instructor, quarter: displayTerm.quarter, year: displayTerm.year,
         department: params.department, classNumber: params.classNumber,
         classCode: params.classCode, courseList: data
     };


### PR DESCRIPTION
# Summary
Added 2020-2021 Spring Quarter to be excluded by the COVID-19 option. 

# Test Plan
- Select the year as `2020-2021` and the quarter as `Spring`.
- Select the `Exclude COVID-19` option.
- Verify that no classes are shown.

# Issues
Resolves issue #9 