### PR TITLE
Relabeled Exclude P/NP to reduce confusion about its functionality

### DIFF
--- a/src/Components/Search/SearchForm.js
+++ b/src/Components/Search/SearchForm.js
@@ -151,7 +151,7 @@ export default function SearchForm({ formID, instructors, handleFormValueChange,
                       }}
                       type="checkbox"
                       id={`exclude-pnp`}
-                      label={`Exclude P/NP`}
+                      label={`Exclude P/NP Only Courses`}
                     />
                   </Col>
                   <Col>


### PR DESCRIPTION
# Summary
Relabeled the checkbox "Exclude P/NP" to "Exclude P/NP Only Courses"

![image](https://user-images.githubusercontent.com/55762196/146253829-62b18279-3d1d-46c1-876c-2d267f8238b4.png)

# Test Plan
- Select "Exclude P/NP Only Courses" checkbox
- Ensures that the label still works as originally intended (When chosen, it excludes all classes that P/NP only when accounting for GPA)

# Note
During the testing of the site, I misinterpreted the meaning of "Exclude P/NP" as excluding students who have taken the class as P/NP no matter if the class is graded P/NP only or includes a letter grade. While Patrick is fixing some of the bugs, he had a similar interpretation as mines. It was not until looking at the Zotistics FAQs that the label truly means "Exclude P/NP Only Courses". The label is a temporary fix to address the ambiguity with the term "Exclude P/NP".

# Issues
Resolves issue #15 