### PR TITLE
Added Summer 2021-22 to COVID-19 quarters

### DIFF
--- a/src/Components/Search/calculations.js
+++ b/src/Components/Search/calculations.js
@@ -162,7 +162,8 @@ export function filter(data, covid19, lowerDiv, upperDiv) {
                 '2020-21 SUMMER',
                 '2020-21 FALL',
                 '2020-21 WINTER',
-                '2020-21 SPRING'
+                '2020-21 SPRING',
+                "2021-22 SUMMER"
             ]);
 
             if (covid_quarters.has(co.year + " " + co.quarter.toUpperCase())) {


### PR DESCRIPTION
# Description
Added Summer 2021-22 to be excluded using the `Exclude COVID-19` option.

# Test Plan
1. Select `Alfaro, S.` as the instructor.
2. Select the `Exclude COVID-19` option.
3. Verify that Summer 2021-22 classes are excluded by clicking on the classes panel.