### PR TITLE
Fixed "Dog Div Covers Components"

### DIFF
--- a/src/Components/Dog/dog.css
+++ b/src/Components/Dog/dog.css
@@ -3,10 +3,11 @@
     left:1em;
     bottom:0;
     z-index:1;
+    width:14%;
 }
 
 img{
-    max-width:33%;
+    max-width: 100%;
     height: auto;
     transition: transform 0.2s ease-in-out;
 }
@@ -16,3 +17,13 @@ img:hover{
     cursor:pointer;
 }
 
+@media screen and (max-width: 660px) and (max-height: 560px) {
+    #dog {
+        width: 0%;
+    }
+}
+@media screen and (max-height: 350px){
+    #dog {
+        width: 0%;
+    }
+}


### PR DESCRIPTION
# Summary
  - Re-adjusted how "max-widths" were being applied on the dog div and the img
  - Applied media queries to remove the dog once the height gets really small so it doesn't overlap 

![image](https://user-images.githubusercontent.com/65634473/149644109-5bde3878-80be-440e-989b-a5bc690f1737.png)

# Issues
Resolved issue #24  